### PR TITLE
Update composer.json to add pcntl as a platform requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "magento/framework": "^101.0.0|^102.0.0|^103.0.0"
+        "magento/framework": "^101.0.0|^102.0.0|^103.0.0",
+        "ext-pcntl": "*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Added pcntl as a requirement since it's not compiled/enabled in the PHP core by default, or _at all_ for Windows
Source: https://www.php.net/manual/en/pcntl.installation.php

Easily ignored by `composer install --ignore-platform-req=pcntl` so it doesn't block developers/CI while ensuring compatibility